### PR TITLE
chore(deps): Bump bcgov-nr/action-deployer-openshift from 1.1.1 to 1.2.1

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -51,7 +51,7 @@ jobs:
             file: backend/openshift.deploy.yml
             overwrite: true
     steps:
-      - uses: bcgov-nr/action-deployer-openshift@v1.1.1
+      - uses: bcgov-nr/action-deployer-openshift@v1.2.1
         with:
           file: ${{ matrix.file }}
           oc_namespace: ${{ vars.OC_NAMESPACE }}
@@ -82,7 +82,7 @@ jobs:
             file: backend/openshift.deploy.yml
             overwrite: true
     steps:
-      - uses: bcgov-nr/action-deployer-openshift@v1.1.1
+      - uses: bcgov-nr/action-deployer-openshift@v1.2.1
         with:
           file: ${{ matrix.file }}
           oc_namespace: ${{ vars.OC_NAMESPACE }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -49,7 +49,7 @@ jobs:
             build_context: ./backend
     steps:
       - uses: actions/checkout@v3
-      - uses: bcgov-nr/action-builder-ghcr@v1.1.2
+      - uses: bcgov-nr/action-builder-ghcr@v1.2.0
         with:
           package: ${{ matrix.package }}
           tag: ${{ github.event.number }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -76,7 +76,7 @@ jobs:
               -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
             triggers: ('backend/')
     steps:
-      - uses: bcgov-nr/action-deployer-openshift@v1.1.1
+      - uses: bcgov-nr/action-deployer-openshift@v1.2.1
         with:
           file: ${{ matrix.file }}
           oc_namespace: ${{ vars.OC_NAMESPACE }}


### PR DESCRIPTION
refs: #24 

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-fam-idim-lookup-proxy-26-backend.apps.silver.devops.gov.bc.ca/api) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-fam-idim-lookup-proxy/actions/workflows/merge-main.yml)