### PR TITLE
ci: update GH Ubuntu runners

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   codeql:
     name: Semantic Code Analysis
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
@@ -42,7 +42,7 @@ jobs:
     needs:
       - codeql
     environment: test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         name: [backend]
@@ -73,7 +73,7 @@ jobs:
     needs:
       - deploys-test
     environment: prod
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         name: [backend]
@@ -103,7 +103,7 @@ jobs:
     name: Promote images to PROD
     needs:
       - deploys-prod
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
     strategy:

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -16,10 +16,17 @@ jobs:
     name: Cleanup OpenShift
     runs-on: ubuntu-22.04
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.14.37"
+
       - name: Remove OpenShift artifacts
         run: |
-          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ vars.OC_SERVER }}
-          oc project ${{ vars.OC_NAMESPACE }}
+          # OC Login
+          OC_TEMP_TOKEN=$(curl -k -X POST https://api.silver.devops.gov.bc.ca:6443/api/v1/namespaces/${{ vars.OC_NAMESPACE }}/serviceaccounts/pipeline/token --header "Authorization: Bearer ${{ secrets.OC_TOKEN }}" -d '{"spec": {"expirationSeconds": 600}}' -H 'Content-Type: application/json; charset=utf-8' | jq -r '.status.token' )
+          oc login --token=${OC_TEMP_TOKEN} --server=https://api.silver.devops.gov.bc.ca:6443
+          oc project ${{ vars.OC_NAMESPACE }} # Safeguard!
 
           # Remove old build runs, build pods and deployment pods
           oc delete all,pvc,secret -l app=${{ github.event.repository.name }}-${{ github.event.number }}

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -14,7 +14,7 @@ jobs:
   # Clean up OpenShift when PR closed, no conditions
   cleanup-openshift:
     name: Cleanup OpenShift
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install CLI tools from OpenShift Mirror
         uses: redhat-actions/openshift-tools-installer@v1
@@ -35,7 +35,7 @@ jobs:
   image-promotions:
     name: Image Promotions
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
     strategy:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       DOMAIN: apps.silver.devops.gov.bc.ca
       PREFIX: ${{ github.event.repository.name }}-${{ github.event.number }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     steps:
@@ -36,7 +36,7 @@ jobs:
 
   builds:
     name: Builds
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
     strategy:
@@ -64,7 +64,7 @@ jobs:
     name: Deploys
     needs:
       - builds
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         name: [backend]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
   # tests:
   #   name: Unit Tests
   #   if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-  #   runs-on: ubuntu-22.04
+  #   runs-on: ubuntu-24.04
   #   strategy:
   #     matrix:
   #       dir: [backend]
@@ -50,7 +50,7 @@ jobs:
   trivy:
     name: Trivy Security Scan
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Update GitHub Ubuntu runners from 22.04 to 24.04.  Includes an extra action to install oc, which is absent for 24.04.

UPDATE: This is closely tied to an existing Renovate PR, so I'll add the relevant commit [there](https://github.com/bcgov/nr-fam-idim-lookup-proxy/pull/106).  

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-fam-idim-lookup-proxy-113-backend.apps.silver.devops.gov.bc.ca/api) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-fam-idim-lookup-proxy/actions/workflows/merge-main.yml)