### PR TITLE
ci: disable Dependabot PR updates, using Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-# Dependency updates for GitHub Actions and npm
-# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily


### PR DESCRIPTION
We're using Renovate.  This PR disables Dependabot PR updates, which are just going to be duplicates.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-fam-idim-lookup-proxy-116-backend.apps.silver.devops.gov.bc.ca/api) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-fam-idim-lookup-proxy/actions/workflows/merge-main.yml)