### PR TITLE
ci: prep for update to GitHub Ubuntu runner

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -16,10 +16,17 @@ jobs:
     name: Cleanup OpenShift
     runs-on: ubuntu-22.04
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.14.37"
+
       - name: Remove OpenShift artifacts
         run: |
-          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ vars.OC_SERVER }}
-          oc project ${{ vars.OC_NAMESPACE }}
+          # OC Login
+          OC_TEMP_TOKEN=$(curl -k -X POST https://api.silver.devops.gov.bc.ca:6443/api/v1/namespaces/${{ vars.OC_NAMESPACE }}/serviceaccounts/pipeline/token --header "Authorization: Bearer ${{ secrets.OC_TOKEN }}" -d '{"spec": {"expirationSeconds": 600}}' -H 'Content-Type: application/json; charset=utf-8' | jq -r '.status.token' )
+          oc login --token=${OC_TEMP_TOKEN} --server=https://api.silver.devops.gov.bc.ca:6443
+          oc project ${{ vars.OC_NAMESPACE }} # Safeguard!
 
           # Remove old build runs, build pods and deployment pods
           oc delete all,pvc,secret -l app=${{ github.event.repository.name }}-${{ github.event.number }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
   # tests:
   #   name: Unit Tests
   #   if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-  #   runs-on: ubuntu-22.04
+  #   runs-on: ubuntu-24.04
   #   strategy:
   #     matrix:
   #       dir: [backend]


### PR DESCRIPTION
GitHub's new Ubuntu runner will will no longer have oc preinstalled.  This PR loads it for us when oc is called.

Must merge before dependency PR https://github.com/bcgov/nr-fam-idim-lookup-proxy/pull/106.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-fam-idim-lookup-proxy-118-backend.apps.silver.devops.gov.bc.ca/api) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-fam-idim-lookup-proxy/actions/workflows/merge-main.yml)