### PR TITLE
fix(ci): template apiVersion for autoscaler target

### DIFF
--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -205,7 +205,7 @@ objects:
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
       scaleTargetRef:
-        apiVersion: apps.openshift.io/v1
+        apiVersion: apps/v1
         kind: Deployment
         name: ${NAME}-${ZONE}-${COMPONENT}
       minReplicas: ${{MIN_REPLICAS}}


### PR DESCRIPTION
This was preventing scaling replicas to 3 in TEST and PROD.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-fam-idim-lookup-proxy-120-backend.apps.silver.devops.gov.bc.ca/api) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-fam-idim-lookup-proxy/actions/workflows/merge-main.yml)