### PR TITLE
chore(ci): add quotes to workflow secrets

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -23,7 +23,7 @@ jobs:
       pr: ${{ steps.pr.outputs.pr }}
     runs-on: ubuntu-24.04
     steps:
-        # Get PR number for squash merges to main
+      # Get PR number for squash merges to main
       - id: pr
         uses: bcgov/action-get-pr@v0.0.1
 
@@ -47,13 +47,12 @@ jobs:
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
-          parameters:
-            -p ZONE=test -p TAG=${{ needs.init.outputs.pr }}
+          parameters: -p ZONE=test -p TAG=${{ needs.init.outputs.pr }}
             ${{ matrix.parameters }}
             -p IDIM_WEB_SERVICE_URL=${{ vars.IDIM_WEB_SERVICE_URL }}
             -p IDIM_WEB_SERVICE_ID=${{ secrets.IDIM_WEB_SERVICE_ID }}
-            -p IDIM_WEB_SERVICE_USERNAME=${{ secrets.IDIM_WEB_SERVICE_USERNAME }}
-            -p IDIM_WEB_SERVICE_PASSWORD=${{ secrets.IDIM_WEB_SERVICE_PASSWORD }}
+            -p IDIM_WEB_SERVICE_USERNAME='${{ secrets.IDIM_WEB_SERVICE_USERNAME }}'
+            -p IDIM_WEB_SERVICE_PASSWORD='${{ secrets.IDIM_WEB_SERVICE_PASSWORD }}'
             -p API_KEY=${{ secrets.API_KEY }}
 
   deploys-prod:
@@ -76,8 +75,7 @@ jobs:
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
-          parameters:
-            -p ZONE=prod -p TAG=${{ needs.init.outputs.pr }}
+          parameters: -p ZONE=prod -p TAG=${{ needs.init.outputs.pr }}
             ${{ matrix.parameters }}
             -p IDIM_WEB_SERVICE_URL=${{ vars.IDIM_WEB_SERVICE_URL }}
             -p IDIM_WEB_SERVICE_ID=${{ secrets.IDIM_WEB_SERVICE_ID }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
-  
+
 concurrency:
   # PR open and close use the same group, allowing only one at a time
   group: pr-${{ github.workflow }}-${{ github.event.number }}
@@ -65,8 +65,8 @@ jobs:
             -p ZONE=${{ github.event.number }} -p TAG=${{ github.event.number }}
             -p IDIM_WEB_SERVICE_URL=${{ vars.IDIM_WEB_SERVICE_URL }}
             -p IDIM_WEB_SERVICE_ID=${{ secrets.IDIM_WEB_SERVICE_ID }}
-            -p IDIM_WEB_SERVICE_USERNAME=${{ secrets.IDIM_WEB_SERVICE_USERNAME }}
-            -p IDIM_WEB_SERVICE_PASSWORD=${{ secrets.IDIM_WEB_SERVICE_PASSWORD }}
+            -p IDIM_WEB_SERVICE_USERNAME='${{ secrets.IDIM_WEB_SERVICE_USERNAME }}'
+            -p IDIM_WEB_SERVICE_PASSWORD='${{ secrets.IDIM_WEB_SERVICE_PASSWORD }}'
             -p API_KEY=${{ secrets.API_KEY }}
             ${{ matrix.parameters }}
           triggers: ${{ matrix.triggers }}


### PR DESCRIPTION
There has been some weirdness around the IDIM_WEB_SERVICE_PASSWORD, so we have wrapped it in quotes.  Co-authored by @ianliuwk1019 during a Teams call.