### PR TITLE
fix: #2030 add ignore script prevent supply chain attack

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: bcgov/action-test-and-analyse@v1.4.0
         with:
           commands: |
-            npm ci
+            npm ci --ignore-scripts
             npm run test:cov
           dir: ${{ matrix.dir }}
           node_version: "20"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 # Local Setup
 
 -   Copy the content in the `local-dev.env` file and create a `.env` file. Update the value of the enviornment secrets (The secrets value can be found in our Openshift namespace e4bc30).
--   Install the packages `npm install`
+-   Install the packages `npm install  --ignore-scripts`
 -   Run the application `npm run start`
 
 # Acknowledgements

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   # Local dev - docker compose up dev
   dev:
     profiles: ["dev"]
-    entrypoint: ["sh", "-c", "npm i && npm run start"]
+    entrypoint: ["sh", "-c", "npm i --ignore-scripts && npm run start"]
     image: node:18
     volumes: ["./backend:/app:z", "/app/node_modules"]
     <<: *common
@@ -18,7 +18,7 @@ services:
   # Local test - docker compose up dev
   test:
     profiles: ["test"]
-    entrypoint: ["sh", "-c", "npm i && npm run test"]
+    entrypoint: ["sh", "-c", "npm i --ignore-scripts && npm run test"]
     image: node:18
     volumes: ["./backend:/app:z", "/app/node_modules"]
     <<: *common


### PR DESCRIPTION
Re: Shai Hulud 2
Fix: via @basilv
This PR implements a security mitigation against the Shai Hulud 2 npm supply chain attack by adding the --ignore-scripts flag to npm ci commands across build environments. This prevents potentially malicious install scripts from executing during package installation.